### PR TITLE
mommy has zsh completion integration~

### DIFF
--- a/src/main/zsh/_mommy
+++ b/src/main/zsh/_mommy
@@ -1,0 +1,23 @@
+#compdef mommy
+
+local exit_codes state
+
+exit_codes=(
+    0:"Success"
+    1:"Error"
+)
+
+_arguments \
+    "(- *)"{-h,--help}'[Show manual]' \
+    "(- *)"{-v,--version}'[Show version]' \
+    -1'[Write to stdout]' \
+    {-c,--config}'[Configuration file]:config:_files' \
+    {-e,--eval}'[Evaluate string]:string' \
+    {-s,--status}'[Exit code]:code:->status' \
+    '*::command:'
+
+# suggest exit codes for --status
+# $state is required, otherwise it'll always suggest exit codes
+[[ $state == status ]] && _describe -t code "Exit code" exit_codes
+
+# vim: ft=zsh


### PR DESCRIPTION
#43 

also if that's alright i can add to [build.sh](https://github.com/FWDekker/mommy/blob/main/build.sh) so that it copies the definition file to e.g. `/usr/local/share/zsh/site-functions` or `/usr/share/zsh/site-functions` which are the defaults