### PR TITLE
🫣 mommy finds your config with an environment variable now~ +nixos

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,1 @@
-* eol=lf
-src/** eol=lf
+* text=auto eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -551,3 +551,12 @@ jobs:
       - name: Test installed mommy
         shell: msys2 {0}
         run: make system=1 test
+
+  test-nixpkgs:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - run: |
+          nix build --impure --expr '(import <nixpkgs> {}).mommy.overrideAttrs (prev: { src = ./.; ${if prev.version == "1.2.3" then "patches" else null} = []; })'

--- a/README.md
+++ b/README.md
@@ -194,6 +194,50 @@ since mommy is just a shell script these methods also work fine on opensuse~
 </details>
 
 <details>
+<summary>nixpkgs/nixos</summary>
+
+mommy has arrived in nixpkgs, and supports customization directly through nixpkgs~
+
+* you can temporarily install mommy with **nix-shell**~
+
+```
+$ nix-shell -p mommy
+[nix-shell:~]$ mommy
+who's my good girl~
+```
+
+* or you can let mommy live in your NixOS or home-manager system by adding mommy to your nix expression:
+<table>
+    <tr>
+      <th>NixOS (default: <code>/etc/nixos/configuration.nix</code>)</th>
+      <th>home-manager</th>
+    </tr>
+    <tr>
+      <td><pre lang="nix">environment.systemPackages = with pkgs; [
+  mommy
+];</pre></td>
+      <td><pre lang="nix">home.packages = with pkgs; [
+  mommy
+];</pre></td>
+    </tr>
+</table>
+
+ * mommy can be configured like this using home-manager or the nix CLIs too~
+   ``` nix
+   environment.systemPackages = with pkgs; [
+     (mommy.override {
+       mommySettings = {
+         sweetie = "catgirl";
+         # all of mommy's other settings work here too!
+         # please scroll down to find out what they are~
+       };
+     })
+   ];
+   ```
+   
+</details>
+
+<details>
 <summary>windows</summary>
 
 * **wsl** (automatic or manual updates)  

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ much~ ❤️
 
 ## 🚚 installation
 mommy works on any system.
-mommy is tested on ubuntu, debian, archlinux, fedora, macos, freebsd, netbsd, openbsd, and windows~
+mommy is tested on ubuntu, debian, archlinux, fedora, macos, freebsd, netbsd, openbsd, nixpkgs, and windows~
 
 _don't see your favourite distro or package manager listed?
 need help?

--- a/src/main/sh/mommy
+++ b/src/main/sh/mommy
@@ -192,7 +192,7 @@ fill_template() {
 MOMMY_OPT_HELP=""
 MOMMY_OPT_VERSION=""
 MOMMY_OPT_TARGET="2"
-MOMMY_OPT_CONFIG_FILE="$HOME/.config/mommy/config.sh"
+MOMMY_OPT_CONFIG_FILE="${MOMMY_OPT_CONFIG_FILE:-"${XDG_CONFIG_HOME:-"$HOME/.config"}/mommy/config.sh"}"
 MOMMY_OPT_EVAL=""
 MOMMY_OPT_STATUS=""
 


### PR DESCRIPTION
~~i taught mommy this with a js regex: `/(MOMMY_[\w_]+)=("[\s\S]*?")/`, replaced matches w `$1=${$1:-$2}\n` on [regexr](https://regexr.com/)~~

mommy will usually use her default settings~

---

i am bringing mommy on a field trip to [nixpkgs](https://github.com/NixOS/nixpkgs/) (home of [nixos](https://nixos.org)), she is on flight number https://github.com/NixOS/nixpkgs/pull/250034.

---

edit: i just noticed mommy already reads a config file in your home, i think it would be good if `MOMMY_OPT_CONFIG_FILE` was an env var instead