### PR TITLE
✂️ a few simple fixes~

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -247,7 +247,6 @@ jobs:
           echo "::endgroup::"
 
           echo "::group::Commit changes"
-          git add --all
           git config --global user.name "FWDekkerBot"
           git config --global user.email "bot@fwdekker.com"
           git commit -am "🔖 mommy added package mommy $MOMMY_VERSION~"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: write
+  discussions: write
   packages: read
 
 jobs:
@@ -197,11 +198,13 @@ jobs:
         uses: softprops/action-gh-release@v1
         if: github.event_name != 'workflow_dispatch'
         with:
-          draft: false
-          prerelease: false
+          target_commitish: main
           tag_name: ${{ env.MOMMY_VERSION }}
           body_path: RELEASE_NOTES.md
           files: mommy*
+          draft: false
+          prerelease: false
+          discussion_category_name: announcements
 
   release-apt:
     needs: [ release-mommy ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,14 @@ jobs:
           repository: FWDekker/homebrew-mommy
           path: homebrew-mommy
           ref: dev
+      - name: Patch homebrew-mommy
+        working-directory: homebrew-mommy
+        env:
+          RELEVANT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          # Point the formula to the commit that is being tested in this workflow
+          sed -i -e "s|head \(.*\), branch: .*|head \1, revision: \"$RELEVANT_SHA\"|g" mommy.rb
+          git -c user.name="ignore" -c user.email="ignore" commit -am "ignore"
       - name: Test Homebrew package
         run: |
           echo "::group::Enable Homebrew"
@@ -161,9 +169,11 @@ jobs:
         run: chown -R build:build ./aur-mommy/
       - name: Test AUR package
         working-directory: ./aur-mommy/
+        env:
+          RELEVANT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
           echo "::group::Patch"
-          sudo -u build ./update.sh dev
+          sudo -u build ./update.sh "$RELEVANT_SHA"
           echo "::endgroup::"
 
           echo "::group::Build and install"
@@ -312,6 +322,14 @@ jobs:
           repository: FWDekker/homebrew-mommy
           path: homebrew-mommy
           ref: dev
+      - name: Patch homebrew-mommy
+        working-directory: homebrew-mommy
+        env:
+          RELEVANT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          # Point the formula to the commit that is being tested in this workflow
+          sed -i -e "s|head \(.*\), branch: .*|head \1, revision: \"$RELEVANT_SHA\"|g" mommy.rb
+          git -c user.name="ignore" -c user.email="ignore" commit -am "ignore"
       - name: Test Homebrew package
         run: |
           echo "::group::Enable Homebrew"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 # Changelog
+## [Unreleased]
+### added
+* 🪹 mommy now supports newlines in templates using `%%N%%`~ ([#58](https://github.com/FWDekker/mommy/issues/58)) ([#82](https://github.com/FWDekker/mommy/issues/82))
+
+### fixed
+* 🚒 mommy fixes the description url in her manual page~ ([#81](https://github.com/FWDekker/mommy/issues/81)) ([#82](https://github.com/FWDekker/mommy/issues/82))
+
+
 ## [1.2.6] -- 2023-11-29
 ### fixed
 * 🚒 mommy fixes her apt repository release script~ ([#73](https://github.com/FWDekker/mommy/issues/73))

--- a/README.md
+++ b/README.md
@@ -501,6 +501,7 @@ outputs `your mommy loves you`~
 | `%%THEM%%`      | mommy's object pronoun (e.g. him, her, them)      |
 | `%%THEIR%%`     | mommy's possessive pronoun (e.g. his, her, their) |
 | `%%SWEETIE%%`   | what mommy calls you                              |
+| `%%N%%`         | a newline                                         |
 
 ### ✍️ renaming the mommy executable
 if you want to write `daddy npm test` instead of `mommy npm test`, you can create a symlink~

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ---
 
-🚚 [**installation**](#-installation) | 📖 [**usage**](#-usage) | 🙋 [**configuration**](#-configuration) | 🐚 [**shell integration**](#-shell-integration) | ⚗️ [**development**](#%EF%B8%8F-development) | 💖 [**acknowledgements**](#-acknowledgements)
+🚚&nbsp;[**installation**](#-installation) | 📖&nbsp;[**usage**](#-usage) | 🙋&nbsp;[**configuration**](#-configuration) | 🐚&nbsp;[**shell integration**](#-shell-integration) | ⚗️&nbsp;[**development**](#%EF%B8%8F-development) | 💖&nbsp;[**acknowledgements**](#-acknowledgements)
 
 ---
 

--- a/src/main/man/man1/mommy.1
+++ b/src/main/man/man1/mommy.1
@@ -18,7 +18,7 @@ e.g. \fBmommy\fP -s $?
 
 
 .SH description
-https://github.com/FWDekker/mommy/blob/%%VERSION_NUMBER%%/README.md
+https://github.com/FWDekker/mommy/tree/v%%VERSION_NUMBER%%#readme
 
 
 .SH bugs

--- a/src/main/sh/mommy
+++ b/src/main/sh/mommy
@@ -181,7 +181,8 @@ fill_template() {
                           -e "s/%%THEY%%/$they/g" \
                           -e "s/%%THEM%%/$them/g" \
                           -e "s/%%THEIR%%/$their/g" \
-                          -e "s/%%CAREGIVER%%/$caregiver/g")"
+                          -e "s/%%CAREGIVER%%/$caregiver/g" \
+                          -e "s/%%N%%/\\$n/g")"
 
     capitalize "$prefix$template$suffix" "$6"
     return 0

--- a/src/test/sh/unit_spec.sh
+++ b/src/test/sh/unit_spec.sh
@@ -358,6 +358,15 @@ Describe "mommy"
                 The status should be success
             End
 
+            It "replaces %%N%%"
+                set_config "MOMMY_COMPLIMENTS='>bottom%%N%%stimky<'"
+
+                When run "$MOMMY_EXEC" -c "$MOMMY_CONFIG_FILE" true
+                The error should equal ">bottom
+stimky<"
+                The status should be success
+            End
+
             It "prepends the prefix"
                 set_config "MOMMY_COMPLIMENTS='<';MOMMY_PREFIX='woolen'"
 


### PR DESCRIPTION
fixes #58 and fixes #81~

also ensures that creating a discussions thread during a release (which was introduced in #73) actually works now (unlike when i [tried to deploy v1.2.6](https://github.com/FWDekker/mommy/actions/runs/7033116004))~

additionally, while fixing #58, i found that the scripts for testing homebrew and aur actually didn't test whether those packages would still work after pointing to the updated code; they only tested whether the new tests would work with the old release, which is quite weird. therefore, the relevant code has been updated to patch the references appropriately, hence [this commit in `aur-mommy`](https://github.com/FWDekker/aur-mommy/commit/d0df3bcaa879c8b754ccbe0d89c026bb45d87870). and i had to add a `relevant_sha` env variable because there is no single variable during an action that gives the sha of the current head in both `pull_request` and `push` events~