### PR TITLE
🌍 mommy adds a variety of things (but mostly global config files)~

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -55,9 +55,9 @@ jobs:
       - name: Build packages
         run: make dist/generic dist/apk dist/deb dist/rpm dist/pacman
       - name: Upload built package
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: dist
+          name: dist-linux
           path: dist/mommy*
 
   build-macos:
@@ -71,9 +71,9 @@ jobs:
       - name: Build package
         run: make dist/osxpkg
       - name: Upload built package
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: dist
+          name: dist-macos
           path: dist/mommy*
 
   build-freebsd:
@@ -114,9 +114,9 @@ jobs:
 
             gmake dist/freebsd
       - name: Upload built package
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: dist
+          name: dist-freebsd
           path: dist/mommy*
 
   build-netbsd:
@@ -146,9 +146,9 @@ jobs:
             gmake dist/netbsd
             echo "::endgroup::"
       - name: Upload built package
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: dist
+          name: dist-netbsd
           path: dist/mommy*
 
   build-openbsd:
@@ -182,9 +182,9 @@ jobs:
 
             gmake dist/openbsd
       - name: Upload built package
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: dist
+          name: dist-openbsd
           path: dist/mommy*
 
 
@@ -199,12 +199,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Download built packages
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: dist
+          pattern: dist-*
+          merge-multiple: true
+          path: dist
       - name: Extract release notes
         id: extract-release-notes
-        uses: ffurrer2/extract-release-notes@v1
+        uses: ffurrer2/extract-release-notes@v2
         with:
           release_notes_file: RELEASE_NOTES.md
       - name: Prepend release notes
@@ -244,9 +246,10 @@ jobs:
           # Required to push '.deb' to repository
           token: ${{ secrets.personal_access_token }}
       - name: Download built packages
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: dist
+          pattern: dist-*
+          merge-multiple: true
           path: dist-mommy
       - name: Move .deb into apt-mommy
         run: cp dist-mommy/*.deb apt-mommy/deb/
@@ -321,6 +324,12 @@ jobs:
       - name: Update build files
         working-directory: aur-mommy
         run: |
+          if [ "${{ github.event.inputs.dry_run }}" = "false" ]; then
+            empty_option=""
+          else
+            empty_option="--allow-empty"
+          fi;
+
           echo "::group::Fast-forward main"
           sudo -u build git checkout dev
           sudo -u build git checkout master
@@ -335,7 +344,7 @@ jobs:
           sudo -u build git config --global user.name "FWDekkerBot"
           sudo -u build git config --global user.email "bot@fwdekker.com"
           sudo -u build git add --all
-          sudo -u build git commit -m "🔖 mommy updated the build files to mommy $MOMMY_VERSION~"
+          sudo -u build git commit -m "🔖 mommy updated the build files to mommy $MOMMY_VERSION~" "$empty_option"
           echo "::endgroup::"
 
           echo "::group::Fast-forward dev"
@@ -376,6 +385,12 @@ jobs:
       - name: Update formula
         working-directory: homebrew-mommy
         run: |
+          if [ "${{ github.event.inputs.dry_run }}" = "false" ]; then
+            empty_option=""
+          else
+            empty_option="--allow-empty"
+          fi;
+
           echo "::group::Fast-forward main"
           git checkout dev
           git checkout main
@@ -390,7 +405,7 @@ jobs:
           git config --global user.name "FWDekkerBot"
           git config --global user.email "bot@fwdekker.com"
           git add --all
-          git commit -m "🔖 mommy updated the formula to mommy $MOMMY_VERSION~"
+          git commit -m "🔖 mommy updated the formula to mommy $MOMMY_VERSION~" "$empty_option"
           echo "::endgroup::"
 
           echo "::group::Fast-forward dev"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+## [unreleased]
+### added
+* improved input validation
+* improved links (back and forth from toc) in readme
+
+
 ## [1.3.0] -- 2024-01-10
 ### added
 * 🪹 mommy now supports newlines in templates using `%%N%%`~ ([#58](https://github.com/FWDekker/mommy/issues/58)) ([#82](https://github.com/FWDekker/mommy/issues/82))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 ## [unreleased]
 ### added
+* global config file!
 * improved input validation
 * improved links (back and forth from toc) in readme
+
+### fixed
+* an empty config file path is now interpreted as disabling the default config (but not necessarily the global config)
 
 
 ## [1.3.0] -- 2024-01-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 # Changelog
 ## [unreleased]
 ### added
-* global config file!
-* improved input validation
-* improved links (back and forth from toc) in readme
+* 🌍 mommy now supports a global config file that applies to all users, stored for example in `/usr/mommy/config.sh`~ ([#95](https://github.com/FWDekker/mommy/issues/95)) ([#96](https://github.com/FWDekker/mommy/issues/96))
+* 📏 mommy accepts long command-line options for all options (like `--config=<file>` for `-c <file>`)~
 
-### fixed
-* an empty config file path is now interpreted as disabling the default config (but not necessarily the global config)
+### changed
+* 🕳️ mommy now interprets an empty config file path (`-c`) as you not wanting to use a config file~
+* ✅ mommy improved her input validation, giving clearer error messages when something is wrong~
+* 🏓 mommy improved the links to and from the table of contents in her readme~
 
 
 ## [1.3.0] -- 2024-01-10

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ---
 
-🚚&nbsp;[**installation**](#-installation) | 📖&nbsp;[**usage**](#-usage) | 🙋&nbsp;[**configuration**](#-configuration) | 🐚&nbsp;[**shell integration**](#-shell-integration) | ⚗️&nbsp;[**development**](#%EF%B8%8F-development) | 💖&nbsp;[**acknowledgements**](#-acknowledgements)
+<a name="toc"></a>🚚&nbsp;[**installation**](#installation) | 📖&nbsp;[**usage**](#usage) | 🙋&nbsp;[**configuration**](#configuration) | 🐚&nbsp;[**shell integration**](#shell-integration) | ⚗️&nbsp;[**development**](#development) | 💖&nbsp;[**acknowledgements**](#acknowledgements)
 
 ---
 
@@ -20,7 +20,7 @@ much~ ❤️
 ![mommy demo](.github/img/demo.gif)
 
 
-## 🚚 installation
+## 🚚 installation<a name="installation"></a> <small><sup>[top ▲](#toc)</sup></small>
 mommy works on any system.
 mommy is tested on ubuntu, debian, archlinux, fedora, nixpkgs, macos, freebsd, netbsd, openbsd, and windows~
 
@@ -214,7 +214,7 @@ find your operating system and package manager for the right instructions~
     })
   ];
   ```
-  check [the full list of configuration options](#-configuration).
+  check [the full list of configuration options](#configuration).
   note that your nix configuration should use lowercase variable names~
 * **nixos** (persistent)  
   install mommy by adding the following to your nixos configuration (usually in `/etc/nixos/configuration.nix`):
@@ -234,7 +234,7 @@ find your operating system and package manager for the right instructions~
     })
   ];
   ```
-  check [the full list of configuration options](#-configuration).
+  check [the full list of configuration options](#configuration).
   note that your nix configuration should use lowercase variable names~
 
 </details>
@@ -398,13 +398,13 @@ tar -C ./ -xzf mommy-*.tar.gz
 </details>
 
 ### 🔮 what's next?
-check out [how to use mommy](#-usage), read all about [ways you can configure mommy](#-configuration), and
-[integrate mommy with your shell](#-shell-integration)~
+check out [how to use mommy](#usage), read all about [ways you can configure mommy](#configuration), and
+[integrate mommy with your shell](#shell-integration)~
 
 <img width="450px" src=".github/img/sample1.png" alt="mommy integrated with the fish shell" />
 
 
-## 📖 usage
+## 📖 usage<a name="usage"></a> <small><sup>[top ▲](#toc)</sup></small>
 mommy integrates with your normal command-line usage and compliments you if the command succeeds and encourages you if
 it fails~
 
@@ -424,7 +424,7 @@ by default, mommy outputs to stderr, but if you use `mommy -1 [other options]` s
 use `mommy -v` to see which version of mommy you're using~
 
 
-## 🙋 configuration
+## 🙋 configuration<a name="configuration"></a> <small><sup>[top ▲](#toc)</sup></small>
 mommy's behavior can be configured by defining variables in `~/.config/mommy/config.sh`.
 
 > ℹ️ mommy is used to instructions being scribbled down in unusual places, and will check inside `XDG_CONFIG_HOME`
@@ -516,7 +516,7 @@ outputs `your mommy loves you`~
 ### ✍️ renaming the mommy executable
 if you want to write `daddy npm test` instead of `mommy npm test`, you can create a symlink~
 
-> ℹ️ if you [integrate mommy with your shell](#-shell-integration) you won't have to write `daddy` in the first place~
+> ℹ️ if you [integrate mommy with your shell](#shell-integration) you won't have to write `daddy` in the first place~
 
 mommy is installed in slightly different locations on different systems, but you can easily find where mommy is
 installed with `whereis mommy`:
@@ -538,7 +538,7 @@ sudo ln -fs /usr/share/man/man1/mommy.1.gz /usr/share/man/man1/daddy.1.gz
 > ℹ️ uninstalling mommy will not remove the manually created symlinks~
 
 
-## 🐚 shell integration
+## 🐚 shell integration<a name="shell-integration"></a> <small><sup>[top ▲](#toc)</sup></small>
 instead of calling mommy for each command, you can fully integrate mommy with your shell to get mommy's output each time
 you run any command.
 here are some examples on how you can do that in various shells.
@@ -637,7 +637,7 @@ log out and back in, and mommy will appear in your shell~
 </details>
 
 
-## ⚗️ development
+## ⚗️ development<a name="development"></a> <small><sup>[top ▲](#toc)</sup></small>
 this section explains how to build mommy from source, in case you want to help with development or for any other reason~
 
 ### 🎬 run
@@ -790,7 +790,7 @@ surely we'll be able to figure something out together~
 * your pull request should go into `dev`, not into `main`~
 
 
-## 💖 acknowledgements
+## 💖 acknowledgements<a name="acknowledgements"></a> <small><sup>[top ▲](#toc)</sup></small>
 mommy recognises _all_ contributors, no matter the size of the contribution.
 if mommy should add, remove, or change anything here, [open an issue](https://github.com/FWDekker/mommy/issues/new) or
 [contact the author](https://fwdekker.com/about/)~

--- a/README.md
+++ b/README.md
@@ -405,41 +405,64 @@ check out [how to use mommy](#usage), read all about [ways you can configure mom
 
 
 ## 📖 usage<a name="usage"></a> <small><sup>[top ▲](#toc)</sup></small>
-mommy integrates with your normal command-line usage and compliments you if the command succeeds and encourages you if
-it fails~
+mommy processes the output status of a command and compliments you if the command succeeds and encourages you if it
+fails~
+
+you can ask mommy to support you in a few ways, shown below.
+alternatively, you can [integrate mommy into your shell](#shell-integration) so `mommy` is invoked for each command~
 
 ```shell
-$ mommy [-1] [-c config] [command] ...
+$ mommy [command] ...
 # e.g. `mommy npm test`
 
-$ mommy [-1] [-c config] -e eval
+$ mommy -e eval
 # e.g. `mommy -e "ls -l | wc -l"`
 
-$ mommy [-1] [-c config] -s status
-# e.g. `mommy -s $?`
+$ mommy -s status
+# e.g. `mommy -s 0` or `mommy -s $?`
 ```
 
-by default, mommy outputs to stderr, but if you use `mommy -1 [other options]` she'll output to stdout~
+additionally, mommy knows a few extra options, which you can use to discover who mommy is and to tell mommy which
+[configuration files](#configuration) she should use.
 
-use `mommy -v` to see which version of mommy you're using~
+| short option | long option                   | description                                                                               |
+|--------------|-------------------------------|-------------------------------------------------------------------------------------------|
+| `-h`         | `--help`                      | opens mommy's manual page~                                                                |
+| `-v`         | `--version`                   | displays version information~                                                             |
+| `-1`         |                               | writes output to stdout instead of stderr~                                                |
+| `-c <file>`  | `--config=<file>`             | reads [config](#configuration) from `<file>`~                                             |
+|              | `--global-config-dirs=<dirs>` | sets global [configuration](#configuration) dirs to the colon-separated list in `<dirs>`~ |
 
 
 ## 🙋 configuration<a name="configuration"></a> <small><sup>[top ▲](#toc)</sup></small>
-mommy's behavior can be configured by defining variables in `~/.config/mommy/config.sh`.
+mommy's behavior can be configured using config files.
+the easiest way to do so is to add your config to the file `~/.config/mommy/config.sh`.
+you can also set up a global config file that is applied to all users in `/etc/mommy/config.sh`.
+mommy will explain in detail below~
 
-> ℹ️ mommy is used to instructions being scribbled down in unusual places, and will check inside `XDG_CONFIG_HOME`
-> instead of `~/.config/` if the former is set~
+### 🔍 config file locations
+when mommy runs, she will first load the system-wide **global** config file.
+after that, she will read the user-specific **local** config file, overriding the values from the global file~
 
-you can specify a different config file by pointing the environment variable `MOMMY_OPT_CONFIG_FILE` to that file, or by
-running mommy as `mommy -c ./my_config.sh [other options]`~
+* to find the **global** config file, mommy runs the following procedure.
+    1. mommy determines the list of global config dirs.
+        1. if a list is specified using a [command-line option](#usage), that list is used.
+        2. otherwise, the list consists of all directories in `$XDG_CONFIG_DIRS`, plus `/etc/mommy`, plus
+         `/usr/local/etc/mommy/`.
+    2. mommy traverses this list, and stops once she finds a directory that contains the file `config.sh`.
+       this file will be the global config file~
+* to find the **local** config file, mommy runs the following procedure.
+    1. if a config file is specified using a [command-line option](#usage), that file is used. 
+    2. if `$XDG_CONFIG_HOME` is defined, the file `$XDG_CONFIG_HOME/mommy/config.sh` is used.
+    3. otherwise, `$HOME/.config/mommy/config.sh` is used~
 
 ### 🗃️ config file format
-mommy executes the config file as a shell script and keeps the environment variables.
+mommy executes config files as shell scripts and keeps the environment variables.
 so, to change the value of `MOMMY_SWEETIE`, add the following line to your config file:
 ```shell
 MOMMY_SWEETIE="catgirl"
 ```
-make sure you do not put spaces around the `=`~
+make sure you _do not_ put spaces around the `=`, and you _do_ put quotes (`"`) around the value~
 
 ### 👛 available settings
 | variable                       | description                                                                                                                                                                                                                                                                                                                                                 | list? | default       |

--- a/src/main/sh/mommy
+++ b/src/main/sh/mommy
@@ -72,6 +72,22 @@ MOMMY_FORBIDDEN_WORDS=""
 MOMMY_IGNORED_STATUSES="130"
 
 
+## Input validation
+# Writes whitespace-concatenated input arguments to stderr and exits.
+die() { echo "$*" >&2; exit 1; }
+
+# Dies if `$OPTARG` is an empty string.
+require_arg() { if [ -z "$OPTARG" ]; then die "mommy is missing the argument for option '$OPT'~"; fi }
+
+# Dies if `$OPTARG` is not a non-negative integer.
+require_int() {
+    case "$OPTARG" in
+    ''|*[!0-9]*) die "mommy expected the argument for option '$OPT' to be an integer, but it was '$OPTARG'~" ;;
+    *) ;;
+    esac
+}
+
+
 ## Lists
 # A list is a collection of entries. Entries are separated by a forward slash (`/`) or by a newline. Entries containing
 # only whitespace or starting with a `#` are considered comments and are ignored. If a line starts with a `#`, all `/`
@@ -121,7 +137,7 @@ escape_sed_replacement() {
 }
 
 
-## Functions
+## Templates
 # Prints `$2`, but with color depending on `$1`. If `$1` equals `lolcat`, stdin is piped to `lolcat`. If `$1` is empty,
 # or color is not enabled in the terminal, stdin is printed normally. Otherwise, `$1` is used as the xterm color.
 color_echo() {
@@ -197,29 +213,32 @@ fill_template() {
 
 
 ## Read options
-MOMMY_OPT_HELP=""
-MOMMY_OPT_VERSION=""
-MOMMY_OPT_TARGET="2"
-MOMMY_OPT_CONFIG_FILE="${MOMMY_OPT_CONFIG_FILE:-"${XDG_CONFIG_HOME:-"$HOME/.config"}/mommy/config.sh"}"
-MOMMY_OPT_EVAL=""
-MOMMY_OPT_STATUS=""
+opt_help=""
+opt_version=""
+opt_target="2"
+opt_config="${opt_config:-"${XDG_CONFIG_HOME:-"$HOME/.config"}/mommy/config.sh"}"
+opt_eval=""
+opt_status=""
 
-while getopts ":hv1c:e:s:-:" OPTION; do
-    # Cheap workaround for long options without arguments
-    if [ "$OPTION" = "-" ]; then
-        OPTION="$OPTARG"
+while getopts ":hv1c:e:s:-:" OPT; do
+    # Cheap workaround for long options, cf. https://stackoverflow.com/a/28466267
+    if [ "$OPT" = "-" ]; then
+        OPT="${OPTARG%%=*}"
+        OPTARG="${OPTARG#$OPT}"
+        OPTARG="${OPTARG#=}"
     fi
 
     # shellcheck disable=SC2214 # Handled by workaround
-    case "$OPTION" in
-    h|help) MOMMY_OPT_HELP="1" ;;
-    v|version) MOMMY_OPT_VERSION="1" ;;
-    1) MOMMY_OPT_TARGET="1" ;;
-    c) MOMMY_OPT_CONFIG_FILE="$OPTARG" ;;
-    e) MOMMY_OPT_EVAL="$OPTARG" ;;
-    s) MOMMY_OPT_STATUS="$OPTARG" ;;
-    ?) echo "mommy does not know option -$OPTARG~" >&2; exit 1 ;;
-    *) echo "mommy does not know option --$OPTION~" >&2; exit 1 ;;
+    case "$OPT" in
+    h|help) opt_help="1" ;;
+    v|version) opt_version="1" ;;
+    1) opt_target="1" ;;
+    c|config) require_arg; opt_config="$OPTARG" ;;
+    e|eval) require_arg; opt_eval="$OPTARG" ;;
+    s|status) require_arg; require_int; opt_status="$OPTARG" ;;
+    :) die "mommy's last option is missing its argument~" ;;
+    ?) die "mommy doesn't know option -$OPTARG~" ;;
+    *) die "mommy doesn't know option --$OPT~" ;;
     esac
 done
 
@@ -227,34 +246,32 @@ shift "$((OPTIND - 1))"
 
 
 ## Load configuration
-# shellcheck disable=SC1090 # User-defined target
-[ -r "$MOMMY_OPT_CONFIG_FILE" ] && . "$MOMMY_OPT_CONFIG_FILE"
+# shellcheck source=/dev/null # User-defined target
+[ -f "$opt_config" ] && [ -r "$opt_config" ] && . "$opt_config"
 
 
 ## Output
-if [ -n "$MOMMY_OPT_HELP" ]; then
+if [ -n "$opt_help" ]; then
     man mommy
 
     status="$?"
     if [ "$status" -ne 0 ]; then
-        printf "%s" \
-            "oops! " \
-            "mommy couldn't find the help page. " \
-            "but you can visit https://github.com/FWDekker/mommy/blob/%%VERSION_NUMBER%%/README.md for more " \
-            "information~" \
-            "$n" >&2
+        die "oops!" \
+            "mommy couldn't find the help page." \
+            "but you can visit https://github.com/FWDekker/mommy/blob/%%VERSION_NUMBER%%/README.md for more" \
+            "information~"
     fi
     exit "$status"
-elif [ -n "$MOMMY_OPT_VERSION" ]; then
+elif [ -n "$opt_version" ]; then
     echo "mommy, v%%VERSION_NUMBER%%, %%VERSION_DATE%%"
     exit 0
 else
     # Run command
-    if [ -n "$MOMMY_OPT_EVAL" ]; then
-        (eval "$MOMMY_OPT_EVAL")
+    if [ -n "$opt_eval" ]; then
+        (eval "$opt_eval")
         command_exit_code="$?"
-    elif [ -n "$MOMMY_OPT_STATUS" ]; then
-        command_exit_code="$MOMMY_OPT_STATUS"
+    elif [ -n "$opt_status" ]; then
+        command_exit_code="$opt_status"
     else
         ("$@")
         command_exit_code="$?"
@@ -281,7 +298,7 @@ else
                                   "$MOMMY_SUFFIX" "$MOMMY_CAPITALIZE")"
 
     # Output template
-    case "$MOMMY_OPT_TARGET" in
+    case "$opt_target" in
     1) color_echo "$color" "$response" >&1 ;;
     2) color_echo "$color" "$response" >&2 ;;
     esac

--- a/src/main/sh/mommy
+++ b/src/main/sh/mommy
@@ -1,5 +1,4 @@
 #!/bin/sh
-
 n="
 "
 
@@ -217,6 +216,7 @@ opt_help=""
 opt_version=""
 opt_target="2"
 opt_config="${opt_config:-"${XDG_CONFIG_HOME:-"$HOME/.config"}/mommy/config.sh"}"
+opt_global_config_dirs="${XDG_CONFIG_DIRS}:/etc/mommy/:/usr/local/etc/mommy/"
 opt_eval=""
 opt_status=""
 
@@ -233,7 +233,8 @@ while getopts ":hv1c:e:s:-:" OPT; do
     h|help) opt_help="1" ;;
     v|version) opt_version="1" ;;
     1) opt_target="1" ;;
-    c|config) require_arg; opt_config="$OPTARG" ;;
+    global-config-dirs) require_arg; opt_global_config_dirs="$OPTARG" ;;
+    c|config) opt_config="$OPTARG" ;;
     e|eval) require_arg; opt_eval="$OPTARG" ;;
     s|status) require_arg; require_int; opt_status="$OPTARG" ;;
     :) die "mommy's last option is missing its argument~" ;;
@@ -246,6 +247,20 @@ shift "$((OPTIND - 1))"
 
 
 ## Load configuration
+# Global
+config_dir=""
+while [ "$opt_global_config_dirs" != "$config_dir" ] ;do
+    config_dir="${opt_global_config_dirs%%:*}"
+    opt_global_config_dirs="${opt_global_config_dirs#$config_dir:}"
+
+    if [ -d "$config_dir" ] && [ -f "$config_dir/config.sh" ] && [ -r "$config_dir/config.sh" ]; then
+        # shellcheck source=/dev/null # User-defined target
+        . "$config_dir/config.sh"
+        break
+    fi
+done
+
+# User
 # shellcheck source=/dev/null # User-defined target
 [ -f "$opt_config" ] && [ -r "$opt_config" ] && . "$opt_config"
 

--- a/src/test/helper/spec_helper.sh
+++ b/src/test/helper/spec_helper.sh
@@ -17,9 +17,11 @@ export MOMMY_EXEC
 export MOMMY_TMP_DIR
 
 
-## Constants
+## Constants and helpers
 export n="
 "
+
+strip_opt() { echo "$1" | sed "s/[-= ]//g"; }
 
 
 ## Hooks

--- a/src/test/helper/spec_helper.sh
+++ b/src/test/helper/spec_helper.sh
@@ -33,7 +33,7 @@ spec_helper_configure() {
 }
 
 mommy_before_each() {
-    mkdir -p "$MOMMY_TMP_DIR"
+    mkdir -p "$MOMMY_TMP_DIR" "$MOMMY_TMP_DIR/global1/" "$MOMMY_TMP_DIR/global2/"
 }
 
 mommy_after_each() {

--- a/src/test/sh/integration_spec.sh
+++ b/src/test/sh/integration_spec.sh
@@ -24,8 +24,8 @@ Describe "integration of mommy with other programs"
         }
 
         It "uninstalls all files that are installed"
-            $MOMMY_MAKE -C ../../../ prefix="$MOMMY_TMP_DIR/" install >/dev/null
-            $MOMMY_MAKE -C ../../../ prefix="$MOMMY_TMP_DIR/" uninstall >/dev/null
+            "$MOMMY_MAKE" -C ../../../ prefix="$MOMMY_TMP_DIR/" install >/dev/null
+            "$MOMMY_MAKE" -C ../../../ prefix="$MOMMY_TMP_DIR/" uninstall >/dev/null
 
             Assert is_empty "$MOMMY_TMP_DIR/"
         End

--- a/src/test/sh/integration_spec.sh
+++ b/src/test/sh/integration_spec.sh
@@ -38,40 +38,31 @@ Describe "integration of mommy with other programs"
         man_before_each() {
             unset MANPATH  # Required on Windows
             if [ "$MOMMY_SYSTEM" != "1" ]; then
-                export MANPATH="$(readlink -f "$(pwd)/../../main/man/")"
+                MANPATH="$(readlink -f "$(pwd)/../../main/man/")"
+                export MANPATH
             fi
         }
         BeforeEach "man_before_each"
 
 
-        It "outputs help information using -h"
-            When run "$MOMMY_EXEC" -h
+        Parameters:value "-h" "--help"
+
+        It "outputs help information using $1"
+            When run "$MOMMY_EXEC" "$1"
             The word 1 of output should equal "mommy(1)"
             The status should be success
         End
 
-        It "outputs help information using --help"
-            When run "$MOMMY_EXEC" --help
+        It "outputs help information even when $1 is not the first option"
+            When run "$MOMMY_EXEC" -s 432 "$1"
             The word 1 of output should equal "mommy(1)"
             The status should be success
         End
 
-        It "outputs help information even when -h is not the first option"
-            When run "$MOMMY_EXEC" -s 432 -h
-            The word 1 of output should equal "mommy(1)"
-            The status should be success
-        End
-
-        It "outputs help information even when --help is not the first option"
-            When run "$MOMMY_EXEC" -s 221 --help
-            The word 1 of output should equal "mommy(1)"
-            The status should be success
-        End
-
-        It "outputs a link to github if the manual page could not be found when using -h"
+        It "outputs a link to github if the manual page could not be found when using $1"
             export MANPATH="/invalid-path"
 
-            When run "$MOMMY_EXEC" -h
+            When run "$MOMMY_EXEC" "$1"
             The output should equal ""
             The error should include "github.com"
             The status should be failure

--- a/src/test/sh/unit_spec.sh
+++ b/src/test/sh/unit_spec.sh
@@ -16,45 +16,37 @@ Describe "mommy"
     Describe "command-line options"
         It "gives an error for unknown short options"
             When run "$MOMMY_EXEC" -d
-            The error should equal "mommy does not know option -d~"
+            The error should equal "mommy doesn't know option -d~"
             The status should be failure
         End
 
         It "gives an error for unknown long options"
             When run "$MOMMY_EXEC" --doesnotexist
-            The error should equal "mommy does not know option --doesnotexist~"
+            The error should equal "mommy doesn't know option --doesnotexist~"
+            The status should be failure
+        End
+
+        It "gives an error for missing required argument to short option when no command is given"
+            When run "$MOMMY_EXEC" -s
+            The error should equal "mommy's last option is missing its argument~"
             The status should be failure
         End
 
         # -h/--help is tested in `integration_spec.sh`
 
         Describe "-v/--version: version information"
-            It "outputs version information using -v"
-                When run "$MOMMY_EXEC" -v
+            Parameters:value "-v" "--version"
+
+            It "outputs version information using $1"
+                When run "$MOMMY_EXEC" "$1"
                 The word 1 of output should equal "mommy,"
                 The word 2 of output should match pattern "v%%VERSION_NUMBER%%,|v[0-9a-z\.\+]*,"
                 The word 3 of output should match pattern "%%VERSION_DATE%%|[0-9]*-[0-9]*-[0-9]*"
                 The status should be success
             End
 
-            It "outputs version information using --version"
-                When run "$MOMMY_EXEC" --version
-                The word 1 of output should equal "mommy,"
-                The word 2 of output should match pattern "v%%VERSION_NUMBER%%,|v[0-9a-z\.\+]*,"
-                The word 3 of output should match pattern "%%VERSION_DATE%%|[0-9]*-[0-9]*-[0-9]*"
-                The status should be success
-            End
-
-            It "outputs version information even when --v is not the first option"
-                When run "$MOMMY_EXEC" -s 138 --v
-                The word 1 of output should equal "mommy,"
-                The word 2 of output should match pattern "v%%VERSION_NUMBER%%,|v[0-9a-z\.\+]*,"
-                The word 3 of output should match pattern "%%VERSION_DATE%%|[0-9]*-[0-9]*-[0-9]*"
-                The status should be success
-            End
-
-            It "outputs version information even when --version is not the first option"
-                When run "$MOMMY_EXEC" -s 911 --version
+            It "outputs version information even when $1 is not the first option"
+                When run "$MOMMY_EXEC" -s 138 "$1"
                 The word 1 of output should equal "mommy,"
                 The word 2 of output should match pattern "v%%VERSION_NUMBER%%,|v[0-9a-z\.\+]*,"
                 The word 3 of output should match pattern "%%VERSION_DATE%%|[0-9]*-[0-9]*-[0-9]*"
@@ -82,17 +74,31 @@ Describe "mommy"
             End
         End
 
-        Describe "-c: custom configuration file"
-            It "ignores an invalid path"
-                When run "$MOMMY_EXEC" -c "./does_not_exist" true
+        Describe "-c/--c/--config: custom configuration file"
+            Parameters:value "-c " "--config="
+
+            It "gives an error when no argument is given with $1"
+                When run "$MOMMY_EXEC" $1"" true
+                The error should equal "mommy is missing the argument for option '$(strip_opt "$1")'~"
+                The status should be failure
+            End
+
+            It "ignores an invalid path given to $1"
+                When run "$MOMMY_EXEC" $1"./does_not_exist" true
                 The error should not equal ""
                 The status should be success
             End
 
-            It "uses the configuration from the given file"
+            It "ignores a directory path given to $1"
+                When run "$MOMMY_EXEC" "$1""." true
+                The error should not equal ""
+                The status should be success
+            End
+
+            It "uses the configuration from the file given to $1"
                 set_config "MOMMY_COMPLIMENTS='apply news'"
 
-                When run "$MOMMY_EXEC" -c "$MOMMY_CONFIG_FILE" true
+                When run "$MOMMY_EXEC" $1"$MOMMY_CONFIG_FILE" true
                 The error should equal "apply news"
                 The status should be success
             End
@@ -131,75 +137,98 @@ Describe "mommy"
             End
         End
 
-        Describe "-e: eval"
-            It "writes a compliment to stderr if the evaluated command returns 0 status"
+        Describe "-e/--eval: eval"
+            Parameters:value "-e " "--eval="
+
+            It "gives an error when no argument is given with $1"
+                When run "$MOMMY_EXEC" $1""
+                The error should equal "mommy is missing the argument for option '$(strip_opt "$1")'~"
+                The status should be failure
+            End
+
+            It "writes a compliment to stderr if the evaluated command returns 0 status when using $1"
                 set_config "MOMMY_COMPLIMENTS='bold accord'"
 
-                When run "$MOMMY_EXEC" -c "$MOMMY_CONFIG_FILE" -e "true"
+                When run "$MOMMY_EXEC" -c "$MOMMY_CONFIG_FILE" $1"true"
                 The error should equal "bold accord"
                 The status should be success
             End
 
-            It "writes an encouragement to stderr if the evaluated command returns non-0 status"
+            It "writes an encouragement to stderr if the evaluated command returns non-0 status when using $1"
                 set_config "MOMMY_ENCOURAGEMENTS='head log'"
 
-                When run "$MOMMY_EXEC" -c "$MOMMY_CONFIG_FILE" -e "false"
+                When run "$MOMMY_EXEC" -c "$MOMMY_CONFIG_FILE" $1"false"
                 The error should equal "head log"
                 The status should be failure
             End
 
-            It "returns the non-0 status of the evaluated command"
-                When run "$MOMMY_EXEC" -e "exit 4"
+            It "returns the non-0 status of the evaluated command when using $1"
+                When run "$MOMMY_EXEC" $1"exit 4"
                 The error should not equal ""
                 The status should equal 4
             End
 
-            It "passes all arguments to the command"
+            It "passes all arguments to the command when using $1"
                 set_config "MOMMY_COMPLIMENTS='desire bread'"
 
-                When run "$MOMMY_EXEC" -c "$MOMMY_CONFIG_FILE" -e "echo a b c"
+                When run "$MOMMY_EXEC" -c "$MOMMY_CONFIG_FILE" $1"echo a b c"
                 The output should equal "a b c"
                 The error should equal "desire bread"
                 The status should be success
             End
 
-            It "considers the command a success if all parts succeed"
+            It "considers the command a success if all parts succeed when using $1"
                 set_config "MOMMY_COMPLIMENTS='milk literary'"
 
-                When run "$MOMMY_EXEC" -c "$MOMMY_CONFIG_FILE" -e "echo 'a/b/c' | cut -d '/' -f 1"
+                When run "$MOMMY_EXEC" -c "$MOMMY_CONFIG_FILE" $1"echo 'a/b/c' | cut -d '/' -f 1"
                 The output should be present
                 The error should equal "milk literary"
                 The status should be success
             End
 
-            It "considers the command a failure if any part fails"
+            It "considers the command a failure if any part fails when using $1"
                 set_config "MOMMY_ENCOURAGEMENTS='bear cupboard'"
 
-                When run "$MOMMY_EXEC" -c "$MOMMY_CONFIG_FILE" -e "echo 'a/b/c' | cut -d '/' -f 0"
+                When run "$MOMMY_EXEC" -c "$MOMMY_CONFIG_FILE" $1"echo 'a/b/c' | cut -d '/' -f 0"
                 The error should be present
                 The status should be failure
             End
         End
 
-        Describe "-s: status"
-            It "writes a compliment to stderr if the status is 0"
+        Describe "-s/--status: status"
+            Parameters:value "-s " "--status="
+
+            It "gives an error when no argument is given with $1"
+                When run "$MOMMY_EXEC" $1"" true
+                The error should equal "mommy is missing the argument for option '$(strip_opt "$1")'~"
+                The status should be failure
+            End
+
+            It "gives an error when the given status is not an integer"
+                When run "$MOMMY_EXEC" $1"kick" true
+                The error should equal \
+                    "mommy expected the argument for option '$(strip_opt "$1")' to be an integer, but it was 'kick'~"
+                The status should be failure
+            End
+
+            It "writes a compliment to stderr if the status is 0 when using $1"
                 set_config "MOMMY_COMPLIMENTS='station top'"
 
-                When run "$MOMMY_EXEC" -c "$MOMMY_CONFIG_FILE" -s 0
+                When run "$MOMMY_EXEC" -c "$MOMMY_CONFIG_FILE" $1"0"
                 The error should equal "station top"
                 The status should be success
             End
 
-            It "writes an encouragement to stderr if the status is non-0"
+            It "writes an encouragement to stderr if the status is non-0 when using $1"
                 set_config "MOMMY_ENCOURAGEMENTS='mend journey'"
 
-                When run "$MOMMY_EXEC" -c "$MOMMY_CONFIG_FILE" -s 1
+                When run "$MOMMY_EXEC" -c "$MOMMY_CONFIG_FILE" $1"1"
                 The error should equal "mend journey"
                 The status should be failure
             End
 
-            It "returns the given non-0 status"
-                When run "$MOMMY_EXEC" -s 167
+            It "returns the given non-0 status when using $1"
+                When run "$MOMMY_EXEC" $1"167"
                 The error should not equal ""
                 The status should equal 167
             End


### PR DESCRIPTION
fixes #95~

this adds the ability to define a global config file. that's a config file that is applied to all users. the user's config file in `~/.config/mommy/config.sh` (or wherever it is) then overrides the global config~

the readme fully documents the feature, and the feature is unit-tested~

@ckiee the global config file is hard-coded to have name `config.sh`, and is searched for in directories `$XDG_CONFIG_DIRS`, and `/etc/mommy/`, and `/usr/local/etc/mommy/`. ([you can check the exact definition here.](https://github.com/FWDekker/mommy/tree/107024efbb61db8b1d10db5778458cd6c87a41f7#-config-file-locations)) this is fine for linux, *bsd, and macos. is this also a sensible approach for nixos?
