### PR TITLE
📦 mommy fixes some minor build issues~

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
         run: |
           echo "::group::Enable Homebrew"
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-          mkdir -p "$HOME/.config/fish/"; echo "set -gx fish_complete_path \$fish_complete_path $(brew --prefix)/share/fish/vendor_completions.d/" >> "$HOME/.config/fish/config.fish"
+          mkdir -p "$HOME/.config/fish/"; echo "set -p fish_complete_path $(brew --prefix)/share/fish/vendor_completions.d/" >> "$HOME/.config/fish/config.fish"
           echo "FPATH=\"$(brew --prefix)/share/zsh/site-functions/:\$FPATH\"" >> "$HOME/.zshrc"
           echo "::endgroup::"
 
@@ -289,7 +289,7 @@ jobs:
 
 
   test-macos:
-    runs-on: macos-latest  # fish tests don't seem to work well in macos 14~
+    runs-on: macos-latest
     steps:
       - name: Install dependencies for mommy
         run: |
@@ -298,8 +298,12 @@ jobs:
           brew install shellspec
           echo "::endgroup::"
 
-          echo "::group::Install additional shells"
-          brew install fish
+          echo "::group::Install additional shell(s)"
+          curl -L -o /tmp/fish.pkg \
+            "$(curl -s -L https://fishshell.com/ | \
+                 grep -m 1 -io "https://github\.com/fish-shell/fish-shell/releases/download/[a-z0-9/\.\-]*.pkg")"
+          sudo installer -pkg /tmp/fish.pkg -target /
+          rm /tmp/fish.pkg
           echo "::endgroup::"
 
       - name: Checkout
@@ -344,8 +348,8 @@ jobs:
           git -c user.name="ignore" -c user.email="ignore" commit -am "ignore"
       - name: Test Homebrew package
         run: |
-          echo "::group::Enable Homebrew"
-          mkdir -p "$HOME/.config/fish/"; echo "set -gx fish_complete_path \$fish_complete_path $(brew --prefix)/share/fish/vendor_completions.d/" >> "$HOME/.config/fish/config.fish"
+          echo "::group::Configure shell completions for Brew"
+          mkdir -p "$HOME/.config/fish/"; echo "set -p fish_complete_path $(brew --prefix)/share/fish/vendor_completions.d/" >> "$HOME/.config/fish/config.fish"
           echo "FPATH=\"$(brew --prefix)/share/zsh/site-functions/:\$FPATH\"" >> "$HOME/.zshrc"
           echo "::endgroup::"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -289,7 +289,7 @@ jobs:
 
 
   test-macos:
-    runs-on: macos-12  # fish tests don't seem to work well in macos 14~
+    runs-on: macos-latest  # fish tests don't seem to work well in macos 14~
     steps:
       - name: Install dependencies for mommy
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## [9.9.9] -- 2099-12-31
 ### added
 * 🚀 mommy now explains how to configure [starship](https://starship.rs/)~ ([#135](https://github.com/FWDekker/mommy/pull/135))
+* ☕ mommy explains how to use fish completions on macos~
 
 ### fixed
 * 👹 mommy ensured freebsd builds don't have the target version hardcoded~

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### added
 * 🚀 mommy now explains how to configure [starship](https://starship.rs/)~ ([#135](https://github.com/FWDekker/mommy/pull/135))
 
+### fixed
+* 👹 mommy ensured freebsd builds don't have the target version hardcoded~
+
 
 ## [1.5.1] -- 2024-09-28
 ### added

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -195,6 +195,7 @@ fpm/%: build
 	@fpm -t "$(@:fpm/%=%)" \
 		-p "$(dist_dir)/mommy-$(version).$(@:fpm/%=%)" \
 		--version "$(version)" \
+		--freebsd-osversion "*" \
 		\
 		"$(build_dir)/bin/mommy=$(bin_prefix)/mommy" \
 		"$(build_dir)/man/man1/mommy.1.gz=$(man_prefix)/man1/mommy.1.gz" \

--- a/README.md
+++ b/README.md
@@ -165,12 +165,26 @@ find your operating system and package manager for the right instructions~
   ```
   after installing, check the
   [brew documentation on how to enable shell completions](https://docs.brew.sh/Shell-Completion)~
+
+  if you installed the [fish shell](https://fishshell.com/) from outside [brew](https://brew.sh/), you must add the following to your `~/.config/fish/config.fish` to enable shell completions for mommy:
+  ```shell
+  if test -d (brew --prefix)"/share/fish/completions"
+      set -p fish_complete_path (brew --prefix)"/share/fish/completions"
+  end
+  ```
 * **pkg (github release)** (manual updates)
   ```shell
   # download latest package from github release
   curl -s https://api.github.com/repos/FWDekker/mommy/releases/latest | grep "browser_download_url.*osx\.pkg" | cut -d : -f 2,3 | tr -d \" | xargs curl -sLOJ
   # install package
   sudo installer -pkg ./mommy*+osx.pkg -target /
+  ```
+
+  if you installed the [fish shell](https://fishshell.com/) using [brew](https://brew.sh/), you must add the following to your `~/.config/fish/config.fish` to enable shell completions for mommy:
+  ```shell
+  if test -d /usr/local/share/fish/vendor_completions.d/
+      set -p fish_complete_path /usr/local/share/fish/vendor_completions.d/
+  end
   ```
 </details>
 


### PR DESCRIPTION
1. when fpm builds for freebsd, it inserts the freebsd version into the required architecture, but for some reason defaults to version 13, so that had to be overridden. before the release of freebsd 13, i hadn't encountered any such issues at all;
2. on macos, fish can now be installed either with brew or as a regular package. mommy can be installed with either. thing is, depending on how you install, the fish completions directory changes. so if you install fish and mommy both with brew, or both using a package, it all works, because the completions are installed in the same directory where fish looks for them. but if the installation method differs (say, if you install fish with brew and mommy as a package), then fish cannot find the completions! to resolve this:
    * instructions have been added to the readme informing users how to make sure completions work, and
    * instead of installing fish with brew, the `ci.yml` workflow now installs the fish package, because that feels more canonical;
3. macos tests for zsh now seem to work properly!