### PR TITLE
👹 mommy tests zsh in more distros~

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -463,7 +463,6 @@ jobs:
             echo "::group::Install additional shells"
             sudo pkgin -y in fish zsh
             touch "$HOME/.zshrc"
-            echo "Touched '$HOME/.zshrc'. I am user '$(username)'. Currently I am in directory '$(pwd)'."
             echo "::endgroup::"
 
             echo "::group::Ignore ownership issues"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,14 +3,16 @@ name: 🧪 ci~
 on:
   push:
     paths-ignore:
+      - '.github/img/**'
+      - 'CONTRIBUTING.md'
       - 'README.md'
       - 'SECURITY.md'
-      - '.github/img/**'
   pull_request:
     paths-ignore:
+      - '.github/img/**'
+      - 'CONTRIBUTING.md'
       - 'README.md'
       - 'SECURITY.md'
-      - '.github/img/**'
 
 jobs:
   test-linux:
@@ -134,6 +136,7 @@ jobs:
 
           echo "::group::Install additional shells"
           pacman -S --noconfirm fish zsh
+          touch "$HOME/.zshrc"
           echo "::endgroup::"
 
       - name: Checkout mommy
@@ -213,7 +216,7 @@ jobs:
           echo "::endgroup::"
 
           echo "::group::Install basic packages"
-          dnf -y install git make rpm-build
+          dnf -y install git make rpm-build util-linux-script
           echo "::endgroup::"
 
       - name: Install dependencies for mommy
@@ -231,6 +234,7 @@ jobs:
 
           echo "::group::Install additional shells"
           dnf -y install fish zsh
+          touch "$HOME/.zshrc"
           echo "::endgroup::"
 
       - name: Checkout mommy
@@ -374,44 +378,42 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Test script and package
-        uses: vmactions/freebsd-vm@v1
+        uses: cross-platform-actions/action@v0.28.0
         with:
-          usesh: true
-          prepare: |
-            set -e
-
+          operating_system: freebsd
+          version: "13.5"
+          run: |
             echo "::group::Install basic packages"
-            pkg install -y git gmake
+            sudo pkg install -y git gmake
             echo "::endgroup::"
 
             echo "::group::Install ShellSpec"
             git clone --depth=1 https://github.com/shellspec/shellspec.git /tmp/shellspec
-            gmake -C /tmp/shellspec install
+            sudo gmake -C /tmp/shellspec install
             rm -rf /tmp/shellspec
             echo "::endgroup::"
 
             echo "::group::Install additional shells"
-            pkg install -y fish zsh
+            sudo pkg install -y fish zsh
+            touch "$HOME/.zshrc"
             echo "::endgroup::"
 
             # fpm
               echo "::group::Install fpm: Actually install fpm"
-              pkg install -y devel/ruby-gems
-              gem install --no-document fpm
+              sudo pkg install -y devel/ruby-gems
+              sudo gem install --no-document fpm
               echo "::endgroup::"
 
               echo "::group::Install fpm: Install gtar (workaround for https://github.com/jordansissel/fpm/pull/1922)"
-              pkg install -y gtar
-              mv /usr/bin/tar /usr/bin/bsdtar
-              mv /usr/local/bin/gtar /usr/bin/tar
+              sudo pkg install -y gtar
+              sudo mv /usr/bin/tar /usr/bin/bsdtar
+              sudo mv /usr/local/bin/gtar /usr/bin/tar
               echo "::endgroup::"
             # /fpm
 
             echo "::group::Ignore ownership issues"
             git config --global --add safe.directory "$GITHUB_WORKSPACE"
             echo "::endgroup::"
-          run: |
-            set -e
 
             echo "::group::Test script"
             gmake test
@@ -422,15 +424,15 @@ jobs:
             echo "::endgroup::"
 
             echo "::group::Install package"
-            pkg add ./dist/mommy-*.freebsd
+            sudo pkg add ./dist/mommy-*.freebsd
             echo "::endgroup::"
 
             echo "::group::Test package"
-            MOMMY_SYSTEM=1 gmake test
+            env MOMMY_SYSTEM=1 gmake test
             echo "::endgroup::"
 
             echo "::group::Uninstall package"
-            pkg delete -y mommy
+            sudo pkg delete -y mommy
             echo "::endgroup::"
 
 
@@ -440,14 +442,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Test script and package
-        uses: cross-platform-actions/action@v0.24.0
+        uses: cross-platform-actions/action@v0.28.0
         with:
           operating_system: netbsd
-          version: "10.0"
+          version: "10.1"
           run: |
-            set -e
             export PATH="/usr/sbin:$PATH"  # Add 'pkg_*' commands to path
-            export MOMMY_ZSH_SKIP=1  # zsh completion capturing totally does not work~
+            export MOMMY_ZSH_SKIP=1  # 'script' does not have the '-q' option in OpenBSD
 
             echo "::group::Install basic packages"
             sudo pkgin -y in git gmake mozilla-rootcerts-openssl
@@ -462,6 +463,7 @@ jobs:
             echo "::group::Install additional shells"
             sudo pkgin -y in fish zsh
             touch "$HOME/.zshrc"
+            echo "Touched '$HOME/.zshrc'. I am user '$(username)'. Currently I am in directory '$(pwd)'."
             echo "::endgroup::"
 
             echo "::group::Ignore ownership issues"
@@ -481,7 +483,7 @@ jobs:
             echo "::endgroup::"
 
             echo "::group::Test package"
-            MOMMY_SYSTEM=1 gmake test
+            env MOMMY_SYSTEM=1 gmake test
             echo "::endgroup::"
 
             echo "::group::Uninstall package"
@@ -495,39 +497,37 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install dependencies for mommy && Test script && Build package && Test package
-        uses: vmactions/openbsd-vm@v1
+        uses: cross-platform-actions/action@v0.28.0
         with:
-          usesh: true
-          prepare: |
-            set -e
+          operating_system: openbsd
+          version: "7.7"
+          run: |
+            export MOMMY_ZSH_SKIP=1  # 'script' does not have the '-q' option in OpenBSD
 
             echo "::group::Install basic packages"
-            pkg_add git gmake
+            sudo pkg_add git gmake
             echo "::endgroup::"
 
             echo "::group::Install ShellSpec"
             git clone --depth=1 https://github.com/shellspec/shellspec.git /tmp/shellspec
-            gmake -C /tmp/shellspec install
+            sudo gmake -C /tmp/shellspec install
             rm -rf /tmp/shellspec
             echo "::endgroup::"
 
             echo "::group::Install additional shells"
-            pkg_add fish zsh
+            sudo pkg_add fish zsh
             touch "$HOME/.zshrc"
             echo "::endgroup::"
 
             echo "::group::Install fpm"
-            pkg_add "$(pkg_info -Q ruby | grep "^ruby-[0-9]" | tail -n 1)"
-            /usr/local/bin/gem* install --no-document fpm
-            ln -s "$(echo /usr/local/bin/fpm* | tr ' ' \\n | grep -E '[0-9]+$')" /usr/local/bin/fpm  # Symlink 'fpm' to latest version
+            sudo pkg_add "$(pkg_info -Q ruby | grep "^ruby-[0-9]" | tail -n 1)"
+            sudo /usr/local/bin/gem* install --no-document fpm
+            sudo ln -s "$(echo /usr/local/bin/fpm* | tr ' ' \\n | grep -E '[0-9]+$')" /usr/local/bin/fpm  # Symlink 'fpm' to latest version
             echo "::endgroup::"
 
             echo "::group::Ignore ownership issues"
             git config --global --add safe.directory "$GITHUB_WORKSPACE"
             echo "::endgroup::"
-          run: |
-            set -e
-            export MOMMY_ZSH_SKIP=1  # 'script' does not have the '-q' option in OpenBSD
 
             echo "::group::Test script"
             gmake test
@@ -538,15 +538,15 @@ jobs:
             echo "::endgroup::"
 
             echo "::group::Install package"
-            pkg_add -D unsigned ./dist/mommy-*+openbsd.tgz
+            sudo pkg_add -D unsigned ./dist/mommy-*+openbsd.tgz
             echo "::endgroup::"
 
             echo "::group::Test package"
-            MOMMY_SYSTEM=1 gmake test  # Zsh completion tests do not work in OpenBSD
+            env MOMMY_SYSTEM=1 gmake test
             echo "::endgroup::"
 
             echo "::group::Uninstall package"
-            pkg_delete mommy
+            sudo pkg_delete mommy
             echo "::endgroup::"
 
 


### PR DESCRIPTION
* the fedora build was failing because [the `script` command has been removed from standard installations as of fedora 42](https://discussion.fedoraproject.org/t/usr-bin-script-util-linux-in-f42-is-there-a-replacement/154318). separately installing `util-linux-script` resolved this issue~
* all `vmactions` actions have been replaced by `cross-platform-actions` because these are significantly faster. this also has the side effect of now having to manually describe the latest os versions for these platforms in the actions. the change to `cross-platform-actions` also required adding a few `sudo`s here and there, and adding `env` in front of commands that had environment variables set~
* an attempt was made (again) at getting zsh integration tests working on netbsd and openbsd. this time, i progressed a little bit towards that goal by (1) making sure to `touch ~/.zshrc` to prevent an interactive prompt from appearing, and (2) creating a unified wrapper around the `script` command that works for all targeted operating systems. unfortunately, those two fixes weren't enough, so i gave up...