### PR TITLE
🐫 mommy bumps targets and dependencies~

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -51,7 +51,7 @@ jobs:
           printf "release_aur: '%s'\n" "$RELEASE_AUR"
           printf "release_homebrew: '%s'\n" "$RELEASE_HOMEBREW"
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Extract and validate mommy's version number
         id: mommy_version
         run: |
@@ -82,7 +82,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Install fpm and build dependencies
         run: |
           sudo apt install -y rubygems libarchive-tools rpm zstd
@@ -90,7 +90,7 @@ jobs:
       - name: Build packages
         run: make dist/generic dist/apk dist/deb dist/rpm dist/pacman
       - name: Upload built package
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: dist-linux
           path: dist/mommy*
@@ -100,13 +100,13 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Install fpm
         run: sudo gem install --no-document fpm
       - name: Build package
         run: make dist/osxpkg
       - name: Upload built package
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: dist-macos
           path: dist/mommy*
@@ -116,12 +116,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Install fpm && Build package
-        uses: cross-platform-actions/action@v0.30.0
+        uses: cross-platform-actions/action@v1
         with:
           operating_system: freebsd
-          version: "14.3"
+          version: ${{ vars.FREEBSD_VERSION }}
           run: |
             printf "::group::Install basic packages\n"
             sudo pkg install -y git gmake
@@ -149,7 +149,7 @@ jobs:
             gmake dist/freebsd
             printf "::endgroup::\n"
       - name: Upload built package
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: dist-freebsd
           path: dist/mommy*
@@ -159,12 +159,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Build package
-        uses: cross-platform-actions/action@v0.30.0
+        uses: cross-platform-actions/action@v1
         with:
           operating_system: netbsd
-          version: "10.1"
+          version: ${{ vars.NETBSD_VERSION }}
           run: |
             set -e
             export PATH="/usr/sbin:$PATH"  # Add 'pkg_*' commands to path
@@ -181,7 +181,7 @@ jobs:
             gmake dist/netbsd
             printf "::endgroup::\n"
       - name: Upload built package
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: dist-netbsd
           path: dist/mommy*
@@ -191,12 +191,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Install fpm && Build package
-        uses: cross-platform-actions/action@v0.30.0
+        uses: cross-platform-actions/action@v1
         with:
           operating_system: openbsd
-          version: "7.8"
+          version: ${{ vars.OPENBSD_VERSION }}
           run: |
             printf "::group::Install basic packages\n"
             sudo pkg_add git gmake
@@ -216,7 +216,7 @@ jobs:
             gmake dist/openbsd
             printf "::endgroup::\n"
       - name: Upload built package
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: dist-openbsd
           path: dist/mommy*
@@ -226,12 +226,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Install fpm && Build package
-        uses: cross-platform-actions/action@v0.30.0
+        uses: cross-platform-actions/action@v1
         with:
           operating_system: haiku
-          version: "r1beta5"
+          version: ${{ vars.HAIKU_VERSION }}
           run: |
             printf "::group::Ignore ownership issues\n"
             git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -241,7 +241,7 @@ jobs:
             make dist/haiku
             printf "::endgroup::\n"
       - name: Upload built package
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: dist-haiku
           path: dist/mommy*
@@ -251,7 +251,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Install fpm && Build package
         uses: vmactions/solaris-vm@v1
         with:
@@ -289,7 +289,7 @@ jobs:
             gmake dist/p5p
             printf "::endgroup::\n"
       - name: Upload built package
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: dist-solaris
           path: dist/mommy-*.p5p
@@ -314,9 +314,9 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Download built packages
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           pattern: dist-*
           merge-multiple: true
@@ -340,7 +340,7 @@ jobs:
             --discussion-category announcements
 
       - name: Checkout 'latest'
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: latest
           fetch-depth: 0
@@ -360,11 +360,11 @@ jobs:
 
     steps:
       - name: Checkout mommy
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           path: src-mommy
       - name: Checkout apt-mommy
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: fwdekker/apt-mommy
           path: apt-mommy
@@ -373,7 +373,7 @@ jobs:
           # Required to push '.deb' to repository
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
       - name: Download built packages
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           pattern: dist-*
           merge-multiple: true
@@ -435,12 +435,12 @@ jobs:
           printf "::endgroup::\n"
 
       - name: Checkout mommy
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           path: src-mommy
 
       - name: Checkout aur-mommy
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: fwdekker/aur-mommy
           path: aur-mommy
@@ -501,11 +501,11 @@ jobs:
 
     steps:
       - name: Checkout mommy
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           path: src-mommy
       - name: Checkout homebrew-mommy
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: fwdekker/homebrew-mommy
           path: homebrew-mommy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
           printf "::endgroup::\n"
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Test script
         run: make test
 
@@ -63,7 +63,7 @@ jobs:
           NONINTERACTIVE=1 \
             /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
       - name: Checkout homebrew-mommy
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: fwdekker/homebrew-mommy
           path: homebrew-mommy
@@ -87,6 +87,7 @@ jobs:
 
           printf "::group::Install\n"
           brew tap local/mommy "$(pwd)/homebrew-mommy"
+          brew trust --formula local/mommy/mommy
           brew install mommy --HEAD
           printf "::endgroup::\n"
 
@@ -140,7 +141,7 @@ jobs:
           printf "::endgroup::\n"
 
       - name: Checkout mommy
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           path: mommy
       - name: Fix mommy directory ownership
@@ -174,7 +175,7 @@ jobs:
           printf "::endgroup::\n"
 
       - name: Checkout aur-mommy
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: fwdekker/aur-mommy
           path: aur-mommy
@@ -238,7 +239,7 @@ jobs:
           printf "::endgroup::\n"
 
       - name: Checkout mommy
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           # Checkout to subdirectory is required for 'pkg/rpkg/rpkg.conf' to correctly determine '${git_props:root}'
           path: mommy
@@ -311,7 +312,7 @@ jobs:
           printf "::endgroup::\n"
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Test script
         run: make test
 
@@ -336,7 +337,7 @@ jobs:
           printf "::endgroup::\n"
 
       - name: Checkout homebrew-mommy
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: fwdekker/homebrew-mommy
           path: homebrew-mommy
@@ -359,6 +360,7 @@ jobs:
 
           printf "::group::Install\n"
           brew tap local/mommy "$(pwd)/homebrew-mommy"
+          brew trust --formula local/mommy/mommy
           brew install mommy --HEAD
           printf "::endgroup::\n"
 
@@ -376,12 +378,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Test script and package
-        uses: cross-platform-actions/action@v0.30.0
+        uses: cross-platform-actions/action@v1
         with:
           operating_system: freebsd
-          version: "14.3"
+          version: ${{ vars.FREEBSD_VERSION }}
           run: |
             printf "::group::Install basic packages\n"
             sudo pkg install -y git gmake
@@ -441,12 +443,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Test script and package
-        uses: cross-platform-actions/action@v0.30.0
+        uses: cross-platform-actions/action@v1
         with:
           operating_system: netbsd
-          version: "10.1"
+          version: ${{ vars.NETBSD_VERSION }}
           run: |
             export PATH="/usr/sbin:$PATH"  # Add 'pkg_*' commands to path
             export MOMMY_ZSH_SKIP=1  # 'script' does not have the '-q' option in NetBSD
@@ -457,7 +459,7 @@ jobs:
 
             printf "::group::Install ShellSpec\n"
             git clone --depth=1 https://github.com/shellspec/shellspec.git /tmp/shellspec/
-            sudo gmake -C /tmp/shellspec/ install
+            sudo gmake -C /tmp/shellspec install
             rm -rf /tmp/shellspec
             printf "::endgroup::\n"
 
@@ -495,12 +497,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Install dependencies for mommy && Test script && Build package && Test package
-        uses: cross-platform-actions/action@v0.30.0
+        uses: cross-platform-actions/action@v1
         with:
           operating_system: openbsd
-          version: "7.8"
+          version: ${{ vars.OPENBSD_VERSION }}
           run: |
             export MOMMY_ZSH_SKIP=1  # 'script' does not have the '-q' option in OpenBSD
 
@@ -574,7 +576,7 @@ jobs:
           printf "::endgroup::\n"
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Test script
         shell: msys2 {0}
         run: make test
@@ -590,7 +592,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Enable nix
         uses: DeterminateSystems/nix-installer-action@main
       - name: Enable cache
@@ -605,12 +607,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Test script and package
-        uses: cross-platform-actions/action@v0.30.0
+        uses: cross-platform-actions/action@v1
         with:
           operating_system: haiku
-          version: "r1beta5"
+          version: ${{ vars.HAIKU_VERSION }}
           run: |
             export MOMMY_ZSH_SKIP=1  # Haiku does not have the 'script' command
 
@@ -653,7 +655,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Test script and package
         uses: vmactions/solaris-vm@v1
         with:

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ find your operating system and package manager for the right instructions~
   (requires [brew](https://brew.sh/).)
   ```shell
   brew tap fwdekker/mommy
+  brew trust --formula fwdekker/mommy/mommy  # only if using homebrew 6.0.0 or newer
   brew install mommy
   ```
   after installing, check the [brew documentation on how to enable shell completions](https://docs.brew.sh/Shell-Completion)~
@@ -83,6 +84,7 @@ find your operating system and package manager for the right instructions~
   (requires [brew](https://brew.sh/).)
   ```shell
   brew tap fwdekker/mommy
+  brew trust --formula fwdekker/mommy/mommy  # only if using homebrew 6.0.0 or newer
   brew install mommy
   ```
   after installing, check the [brew documentation on how to enable shell completions](https://docs.brew.sh/Shell-Completion)~
@@ -137,6 +139,7 @@ find your operating system and package manager for the right instructions~
   (requires [brew](https://brew.sh/).)
   ```shell
   brew tap fwdekker/mommy
+  brew trust --formula fwdekker/mommy/mommy  # only if using homebrew 6.0.0 or newer
   brew install mommy
   ```
   after installing, check the [brew documentation on how to enable shell completions](https://docs.brew.sh/Shell-Completion)~
@@ -181,6 +184,7 @@ find your operating system and package manager for the right instructions~
   (requires [brew](https://brew.sh/).)
   ```shell
   brew tap fwdekker/mommy
+  brew trust --formula fwdekker/mommy/mommy  # only if using homebrew 6.0.0 or newer
   brew install mommy
   ```
   after installing, check the [brew documentation on how to enable shell completions](https://docs.brew.sh/Shell-Completion)~
@@ -296,6 +300,7 @@ find your operating system and package manager for the right instructions~
   (requires [brew](https://brew.sh/).)
   ```shell
   brew tap fwdekker/mommy
+  brew trust --formula fwdekker/mommy/mommy  # only if using homebrew 6.0.0 or newer
   brew install mommy
   ```
   after installing, check the


### PR DESCRIPTION
1. updates all github actions used
2. makes sure instructions and github actions use `brew trust` (this is new since homebrew 6.0.0)
3. moves os version numbers used in cross-platform-actions to the [repository variables](https://github.com/fwdekker/mommy/settings/variables/actions)